### PR TITLE
EVA-1077 and EVA-1092 - Read workloads from configuration files + other changes

### DIFF
--- a/database_benchmarking_suite/build.sbt
+++ b/database_benchmarking_suite/build.sbt
@@ -16,7 +16,8 @@ libraryDependencies += "com.datastax.cassandra" % "cassandra-driver-core" % "3.4
 libraryDependencies += "org.rogach" %% "scallop" % "3.1.1"
 //MongoDB library
 libraryDependencies += "org.mongodb.scala" %% "mongo-scala-driver" % "2.2.0"
-
+//Config library
+libraryDependencies += "com.github.pureconfig" %% "pureconfig" % "0.9.0"
 
 assemblyMergeStrategy in assembly := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard

--- a/database_benchmarking_suite/conf/heavy_write_workload.json
+++ b/database_benchmarking_suite/conf/heavy_write_workload.json
@@ -1,0 +1,13 @@
+{
+  "write-workloads": [
+    {
+      "desc": "ins-1B-par",
+      "thread-choices": [8,16,32],
+      "num-ops-per-wu": 1000000000,
+      "num-wu": 2
+    }
+  ],
+  "read-workloads": [
+
+  ]
+}

--- a/database_benchmarking_suite/conf/read_write_workload.json
+++ b/database_benchmarking_suite/conf/read_write_workload.json
@@ -1,0 +1,42 @@
+{
+  "write-workloads": [
+    {
+      "desc": "ins-256k-par",
+      "thread-choices": [4,8,16,32],
+      "num-ops-per-wu": 256000,
+      "num-wu": 50
+    },
+    {
+      "desc": "ins-1B-par",
+      "thread-choices": [8,16,32],
+      "num-ops-per-wu": 1000000000,
+      "num-wu": 2
+    },
+    {
+      "desc": "ins-32k-seq",
+      "thread-choices": [1],
+      "num-ops-per-wu": 32000,
+      "num-wu": 50
+    }
+  ],
+  "read-workloads": [
+    {
+      "desc": "read-256k-par",
+      "thread-choices": [4,8,16,32],
+      "num-ops-per-wu": 256000,
+      "num-wu": 50
+    },
+    {
+      "desc": "read-1B-par",
+      "thread-choices": [8,16,32],
+      "num-ops-per-wu": 1000000000,
+      "num-wu": 2
+    },
+    {
+      "desc": "read-32k-seq",
+      "thread-choices": [1],
+      "num-ops-per-wu": 32000,
+      "num-wu": 50
+    }
+  ]
+}

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/BenchmarkResultCollector.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/BenchmarkResultCollector.scala
@@ -12,8 +12,8 @@ class BenchmarkResultCollector(val summer: Summariser) extends ResultCollector(s
     super.sampleOccurred(e)
     val r = e.getResult
     if (!r.isSuccessful) {
-      System.out.println("Sampler %s failed at !".format(e.getThreadGroup) +
-        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()))
+      System.out.println("Sampler %s failed at %s!".format(e.getThreadGroup,
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())))
       System.out.println(r.getResponseMessage)
     }
   }

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/BenchmarkResultCollector.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/BenchmarkResultCollector.scala
@@ -1,5 +1,8 @@
 package uk.ac.ebi.eva.benchmarking_suite
 
+import java.text.SimpleDateFormat
+import java.util.Date
+
 import org.apache.jmeter.reporters.{ResultCollector, Summariser}
 import org.apache.jmeter.samplers.SampleEvent
 
@@ -9,7 +12,8 @@ class BenchmarkResultCollector(val summer: Summariser) extends ResultCollector(s
     super.sampleOccurred(e)
     val r = e.getResult
     if (!r.isSuccessful) {
-      System.out.println("Run Failed!")
+      System.out.println("Sampler %s failed at !".format(e.getThreadGroup) +
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()))
       System.out.println(r.getResponseMessage)
     }
   }

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/BenchmarkingMain.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/BenchmarkingMain.scala
@@ -75,21 +75,21 @@ object BenchmarkingMain extends App {
 
     //Use two separate tables to facilitate reverse lookup instead of materialized views
     // See https://www.mail-archive.com/user@cassandra.apache.org/msg54073.html for materialized view deprecation
-    val insertIntoLkp = "insert into %s (species, chromosome, start_pos, entity_id, accession_id, raw_numeric_id) "
+    val insertIntoLookup = "insert into %s (species, chromosome, start_pos, entity_id, accession_id, raw_numeric_id) "
       .format(variantTableName) + "values (?, ?, ?, ?, ?, ?);"
-    val insertIntoReverseLkp = ("insert into %s_reverse (accession_id, raw_numeric_id, species, " +
+    val insertIntoReverseLookup = ("insert into %s_reverse (accession_id, raw_numeric_id, species, " +
       "chromosome, start_pos, entity_id) ").format(variantTableName) + "values (?, ?, ?, ?, ?, ?);"
     val blockReadString = "select * from %s where species = ? and chromosome = ? and start_pos >= ? and start_pos <= ?"
       .format(variantTableName)
-    val lkpInsertStmt: PreparedStatement = cassandraSession.prepare(insertIntoLkp)
-    val reverseLkpInsertStmt: PreparedStatement = cassandraSession.prepare(insertIntoReverseLkp)
+    val lookupInsertStmt: PreparedStatement = cassandraSession.prepare(insertIntoLookup)
+    val reverseLookupInsertStmt: PreparedStatement = cassandraSession.prepare(insertIntoReverseLookup)
     val blockReadStatement: PreparedStatement = cassandraSession.prepare(blockReadString)
       .setConsistencyLevel(ConsistencyLevel.QUORUM)
 
     cassandraSession.execute(new SimpleStatement("truncate %s".format(variantTableName)).setReadTimeoutMillis(600000))
 
-    CassandraConnectionParams(cassandraCluster, cassandraSession, lkpInsertStmt,
-      reverseLkpInsertStmt, blockReadStatement)
+    CassandraConnectionParams(cassandraCluster, cassandraSession, lookupInsertStmt,
+      reverseLookupInsertStmt, blockReadStatement)
   }
 
   def getMongoDBConnectionParams(connectionString: String, databaseName: String, collectionName: String):
@@ -174,7 +174,7 @@ class BenchmarkingArgParser(arguments: Seq[String], validDatabases: List[String]
     descr = "Full path to the JMeter installation directory (ex: /opt/jmeter)")
   val outputFile: arg[String] = opt[String](required = true, short = 'o',
     descr = "Path to store the test output (ex: /opt/cassandra_test/results.jtl)")
-  val workloadConfigFile: arg[String] = opt[String](required = true, short = 'f',
+  val workloadConfigFile: arg[String] = opt[String](required = true, short = 'w',
     descr = "Path to workload configuration file (ex: /opt/cassandra_test/read_workloads.json")
 
   validate(databaseType) { (databaseName) =>

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraConnectionParams.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraConnectionParams.scala
@@ -4,13 +4,13 @@ import com.datastax.driver.core.{Cluster, PreparedStatement, Session}
 import uk.ac.ebi.eva.benchmarking_suite.DBConnectionParams
 
 object CassandraConnectionParams {
-    def apply(cluster: Cluster, session: Session, lkpTableInsertStmt: PreparedStatement,
-              reverseLkpTableInsertStmt: PreparedStatement, blockReadStmt: PreparedStatement) =
-      new CassandraConnectionParams(cluster, session, lkpTableInsertStmt, reverseLkpTableInsertStmt, blockReadStmt)
+    def apply(cluster: Cluster, session: Session, lookupTableInsertStmt: PreparedStatement,
+              reverseLookupTableInsertStmt: PreparedStatement, blockReadStmt: PreparedStatement) =
+      new CassandraConnectionParams(cluster, session, lookupTableInsertStmt, reverseLookupTableInsertStmt, blockReadStmt)
 }
 
-class CassandraConnectionParams(val cluster: Cluster, val session: Session, val lkpTableInsertStmt: PreparedStatement,
-                                val reverseLkpTableInsertStmt: PreparedStatement, val blockReadStmt: PreparedStatement)
+class CassandraConnectionParams(val cluster: Cluster, val session: Session, val lookupTableInsertStmt: PreparedStatement,
+                                val reverseLookupTableInsertStmt: PreparedStatement, val blockReadStmt: PreparedStatement)
   extends  DBConnectionParams {
 
   override def cleanup(): Unit = {

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraConnectionParams.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraConnectionParams.scala
@@ -4,12 +4,14 @@ import com.datastax.driver.core.{Cluster, PreparedStatement, Session}
 import uk.ac.ebi.eva.benchmarking_suite.DBConnectionParams
 
 object CassandraConnectionParams {
-    def apply(cluster: Cluster, session: Session, insertStmt: PreparedStatement,
-              blockReadStmt: PreparedStatement) = new CassandraConnectionParams(cluster, session, insertStmt, blockReadStmt)
+    def apply(cluster: Cluster, session: Session, lkpTableInsertStmt: PreparedStatement,
+              reverseLkpTableInsertStmt: PreparedStatement, blockReadStmt: PreparedStatement) =
+      new CassandraConnectionParams(cluster, session, lkpTableInsertStmt, reverseLkpTableInsertStmt, blockReadStmt)
 }
 
-class CassandraConnectionParams(val cluster: Cluster, val session: Session, val insertStmt: PreparedStatement,
-                                val blockReadStmt: PreparedStatement) extends  DBConnectionParams {
+class CassandraConnectionParams(val cluster: Cluster, val session: Session, val lkpTableInsertStmt: PreparedStatement,
+                                val reverseLkpTableInsertStmt: PreparedStatement, val blockReadStmt: PreparedStatement)
+  extends  DBConnectionParams {
 
   override def cleanup(): Unit = {
     session.close()

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraWriteSampler.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraWriteSampler.scala
@@ -50,9 +50,9 @@ class CassandraWriteSampler() extends AbstractSampler {
           accessionId, new Integer(counter))
 
       //Write to 2 tables one for the look-up and the other for the reverse look-up
-      batchStmt.add(cassandraTestParams.lkpTableInsertStmt.bind
+      batchStmt.add(cassandraTestParams.lookupTableInsertStmt.bind
       (species, chromosome, start_pos, entity_id, accession_id, raw_numeric_id))
-      batchStmt.add(cassandraTestParams.reverseLkpTableInsertStmt.bind
+      batchStmt.add(cassandraTestParams.reverseLookupTableInsertStmt.bind
       (accession_id, raw_numeric_id, species, chromosome, start_pos, entity_id))
 
       insertData(threadNum, counter + 1, numInsertsPerThread)

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraWriteSampler.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraWriteSampler.scala
@@ -23,6 +23,7 @@ class CassandraWriteSampler() extends AbstractSampler {
   }
 
   private def getBatchStmt = {
+    //Use logged batches to maintain atomicity/consistency since we are inserting into two tables
     var batchStmt = new BatchStatement(BatchStatement.Type.LOGGED)
     batchStmt.setConsistencyLevel(ConsistencyLevel.QUORUM)
     batchStmt.setReadTimeoutMillis(600000)

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraWriteSampler.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/cassandra/CassandraWriteSampler.scala
@@ -37,13 +37,16 @@ class CassandraWriteSampler() extends AbstractSampler {
     }
 
     if (counter < numInsertsPerThread) {
+      val timeStamp = System.currentTimeMillis()
+      val accessionId = "acc_%d_%d_%s".format(threadNum, counter, timeStamp)
+      val entityId = "ent_%d_%d_%s".format(threadNum, counter, timeStamp)
       val timeForBatchWrite = counter % defaultBatchSize == 0 && counter > 0
       if (timeForBatchWrite) {
         batchWrite
       }
       val (species, chromosome, start_pos, entity_id, accession_id, raw_numeric_id) =
-        ("eva_hsapiens_grch37", threadNum.toString, new Integer(counter + 100), "ent_%d_%d".format(threadNum, counter),
-          "acc_%d_%d".format(threadNum, counter), new Integer(counter))
+        ("eva_hsapiens_grch37", threadNum.toString, new Integer(counter + 100), entityId,
+          accessionId, new Integer(counter))
 
       //Write to 2 tables one for the look-up and the other for the reverse look-up
       batchStmt.add(cassandraTestParams.lkpTableInsertStmt.bind

--- a/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/mongodb/MongoDBWriteSampler.scala
+++ b/database_benchmarking_suite/src/main/scala/uk/ac/ebi/eva/benchmarking_suite/mongodb/MongoDBWriteSampler.scala
@@ -39,9 +39,10 @@ class MongoDBWriteSampler() extends AbstractSampler {
     if (counter < numInsertsPerThread) {
       val timeStamp = System.currentTimeMillis()
       val accessionId = "acc_%d_%d_%s".format(threadNum, counter, timeStamp)
+      val entityId = "ent_%d_%d_%s".format(threadNum, counter, timeStamp)
       val documentToInsert: doc = InsertOneModel(Document(
-        "_id" -> accessionId, "species" -> "eva_hsapiens_grch37", "chromosome" -> ("" + threadNum),
-        "start_pos" -> (counter + 100), "entity_id" -> "ent_%d_%d".format(threadNum, counter),
+        "_id" -> accessionId, "species" -> "eva_hsapiens_grch37", "chromosome" -> threadNum.toString,
+        "start_pos" -> (counter + 100), "entity_id" -> entityId,
         "accession_id" -> accessionId, "raw_numeric_id" -> counter)
       )
       val timeForBatchWrite = counter % defaultBatchSize == 0 && counter > 0


### PR DESCRIPTION
Made the following updates

- Facilitate reading of workload configuration from JSON files
- Better formatting of failure messages in Samplers
- Switch to separate insert into a reverse lookup table instead of materialized views in Cassandra due to possible deprecation of materialized views - https://www.mail-archive.com/user@cassandra.apache.org/msg54073.html
- Make insertion logic somewhat uniform across databases and add timestamps to avoid collisions during multiple runs
- Add explicit majority "Read Concern" for MongoDB reads since that is not the default for versions >= 3.4
